### PR TITLE
feat(site): enable production AdSense and polish branding/content upd…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,4 +19,6 @@ jobs:
           bundler-cache: true
 
       - name: Build site (strict front matter)
+        env:
+          JEKYLL_ENV: production
         run: bundle exec jekyll build --strict_front_matter

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -31,6 +31,8 @@ jobs:
           bundler-cache: true
 
       - name: Build site
+        env:
+          JEKYLL_ENV: production
         run: bundle exec jekyll build
 
       - name: Upload artifact

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -1,9 +1,8 @@
-<!-- Google AdSense placeholder (disabled by default). -->
-<!--
+{% if jekyll.environment == "production" %}
 <script async
-  src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXXXXXX"
+  src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9148159911868814"
   crossorigin="anonymous"></script>
--->
+{% endif %}
 <style>
   :root {
     --theme-toggle-size: 2rem;

--- a/ads.txt
+++ b/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-9148159911868814, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
…ates

- Rebrand blog title/subtitle to "Code to Architecture"
- Improve masthead subtitle styling and sidebar bio display
- Rewrite About page in a professional consulting tone
- Expand/refine new Java + DSA posts and fix internal/external links
- Migrate post banners from PNG to SVG and align visual style
- Fix default-methods Markdown table rendering
- Enable Google AdSense with publisher ID in head include
- Add ads.txt for publisher verification
- Load AdSense only in production (jekyll.environment guard)
- Set JEKYLL_ENV=production in CI and deploy workflows