### PR TITLE
docs: standardize DSA guide titles for interview prep

### DIFF
--- a/_posts/2026-03-01-two-pointers-technique.md
+++ b/_posts/2026-03-01-two-pointers-technique.md
@@ -13,7 +13,7 @@ tags:
 - linked-list
 - algorithms
 - interview-preparation
-title: Two Pointers Technique in Java — A Practical Guide for Serious Engineers
+title: Two Pointers Technique in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-03-13-sliding-window-technique.md
+++ b/_posts/2026-03-13-sliding-window-technique.md
@@ -13,7 +13,7 @@ tags:
 - deque
 - algorithms
 - interview-preparation
-title: Sliding Window Technique in Java — A Detailed Guide for Serious Engineers
+title: Sliding Window Technique in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-03-14-prefix-sum-technique.md
+++ b/_posts/2026-03-14-prefix-sum-technique.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-03-14
-seo_title: Prefix Sum Pattern in Java – Complete Guide for Backend Engineers
+seo_title: Prefix Sum Pattern in Java - Interview Preparation Guide
 seo_description: Master Prefix Sum in Java with core templates, hashmap extensions,
   subarray problems, and production-grade reasoning.
 tags:
@@ -13,7 +13,7 @@ tags:
 - algorithms
 - interview-preparation
 - backend-engineering
-title: Prefix Sum Pattern in Java — A Detailed Guide for Serious Engineers
+title: Prefix Sum Pattern in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-03-15-hashmap-hashset-frequency-pattern.md
+++ b/_posts/2026-03-15-hashmap-hashset-frequency-pattern.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-03-15
-seo_title: HashMap and HashSet Frequency Pattern in Java – Complete Guide
+seo_title: HashMap and HashSet Frequency Pattern in Java - Interview Preparation Guide
 seo_description: Learn HashMap and HashSet frequency patterns in Java with counting,
   lookup, and linear-time matching examples.
 tags:
@@ -13,7 +13,7 @@ tags:
 - hashset
 - frequency-pattern
 - algorithms
-title: HashMap and HashSet Frequency Pattern in Java — A Detailed Guide
+title: HashMap and HashSet Frequency Pattern in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-03-16-binary-search-pattern.md
+++ b/_posts/2026-03-16-binary-search-pattern.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-03-16
-seo_title: Binary Search Pattern in Java – Complete Guide
+seo_title: Binary Search Pattern in Java - Interview Preparation Guide
 seo_description: Master binary search in Java including index search, first/last occurrence,
   and answer-space binary search.
 tags:
@@ -12,7 +12,7 @@ tags:
 - binary-search
 - algorithms
 - interview-preparation
-title: Binary Search Pattern in Java — A Detailed Guide
+title: Binary Search Pattern in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-03-17-monotonic-stack-pattern.md
+++ b/_posts/2026-03-17-monotonic-stack-pattern.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-03-17
-seo_title: Monotonic Stack Pattern in Java – Complete Guide
+seo_title: Monotonic Stack Pattern in Java - Interview Preparation Guide
 seo_description: Learn monotonic stack in Java for next greater/smaller problems,
   range contributions, and linear-time scans.
 tags:
@@ -12,7 +12,7 @@ tags:
 - monotonic-stack
 - stack
 - algorithms
-title: Monotonic Stack Pattern in Java — A Detailed Guide
+title: Monotonic Stack Pattern in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-03-18-monotonic-queue-deque-pattern.md
+++ b/_posts/2026-03-18-monotonic-queue-deque-pattern.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-03-18
-seo_title: Monotonic Queue (Deque) Pattern in Java – Complete Guide
+seo_title: Monotonic Queue (Deque) Pattern in Java - Interview Preparation Guide
 seo_description: Learn monotonic deque pattern in Java for sliding window extrema
   and constrained DP optimizations.
 tags:
@@ -12,7 +12,7 @@ tags:
 - monotonic-queue
 - deque
 - sliding-window
-title: Monotonic Queue (Deque) Pattern in Java — A Detailed Guide
+title: Monotonic Queue (Deque) Pattern in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-03-19-heap-priority-queue-pattern.md
+++ b/_posts/2026-03-19-heap-priority-queue-pattern.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-03-19
-seo_title: Heap and Priority Queue Pattern in Java – Complete Guide
+seo_title: Heap and Priority Queue Pattern in Java - Interview Preparation Guide
 seo_description: Master heap and priority queue patterns in Java for top-k, streaming
   median, scheduling, and greedy optimization.
 tags:
@@ -12,7 +12,7 @@ tags:
 - heap
 - priority-queue
 - algorithms
-title: Heap and Priority Queue Pattern in Java — A Detailed Guide
+title: Heap and Priority Queue Pattern in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-03-20-intervals-pattern.md
+++ b/_posts/2026-03-20-intervals-pattern.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-03-20
-seo_title: Intervals Pattern in Java – Complete Guide
+seo_title: Intervals Pattern in Java - Interview Preparation Guide
 seo_description: Learn interval algorithms in Java including merge, insert, overlap
   detection, and meeting room scheduling.
 tags:
@@ -12,7 +12,7 @@ tags:
 - intervals
 - sorting
 - algorithms
-title: Intervals Pattern in Java — A Detailed Guide
+title: Intervals Pattern in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-03-21-linked-list-patterns.md
+++ b/_posts/2026-03-21-linked-list-patterns.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-03-21
-seo_title: Linked List Patterns in Java – Complete Guide
+seo_title: Linked List Patterns in Java - Interview Preparation Guide
 seo_description: Linked list patterns in Java explained through real-world
   trade-offs, failure modes, performance costs, and interview-ready heuristics.
 tags:
@@ -14,7 +14,7 @@ tags:
 - algorithms
 - performance
 - architecture
-title: Linked List Patterns in Java — A Detailed Guide
+title: Linked List Patterns in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-03-22-backtracking-pattern.md
+++ b/_posts/2026-03-22-backtracking-pattern.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-03-22
-seo_title: Backtracking Pattern in Java – Complete Guide
+seo_title: Backtracking Pattern in Java - Interview Preparation Guide
 seo_description: Learn backtracking in Java with recursion templates for combinations,
   permutations, subsets, and constraint search.
 tags:
@@ -12,7 +12,7 @@ tags:
 - backtracking
 - recursion
 - algorithms
-title: Backtracking Pattern in Java — A Detailed Guide
+title: Backtracking Pattern in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-03-23-tree-dfs-pattern.md
+++ b/_posts/2026-03-23-tree-dfs-pattern.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-03-23
-seo_title: Tree DFS Pattern in Java – Complete Guide
+seo_title: Tree DFS Pattern in Java - Interview Preparation Guide
 seo_description: Master depth-first traversal patterns on binary trees in Java with
   recursion templates and path-based problems.
 tags:
@@ -12,7 +12,7 @@ tags:
 - tree
 - dfs
 - recursion
-title: Tree DFS Pattern in Java — A Detailed Guide
+title: Tree DFS Pattern in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-03-24-tree-bfs-pattern.md
+++ b/_posts/2026-03-24-tree-bfs-pattern.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-03-24
-seo_title: Tree BFS Pattern in Java – Complete Guide
+seo_title: Tree BFS Pattern in Java - Interview Preparation Guide
 seo_description: Learn tree BFS in Java using queue-based level traversal, shortest
   depth, and level-order transformations.
 tags:
@@ -12,7 +12,7 @@ tags:
 - tree
 - bfs
 - queue
-title: Tree BFS Pattern in Java — A Detailed Guide
+title: Tree BFS Pattern in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-03-25-graph-traversal-pattern.md
+++ b/_posts/2026-03-25-graph-traversal-pattern.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-03-25
-seo_title: Graph Traversal Pattern in Java – Complete Guide
+seo_title: Graph Traversal Pattern in Java - Interview Preparation Guide
 seo_description: Learn graph traversal in Java using BFS and DFS with adjacency lists,
   connected components, and traversal safety.
 tags:
@@ -12,7 +12,7 @@ tags:
 - graph
 - bfs
 - dfs
-title: Graph Traversal Pattern in Java — A Detailed Guide
+title: Graph Traversal Pattern in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-03-26-shortest-path-pattern.md
+++ b/_posts/2026-03-26-shortest-path-pattern.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-03-26
-seo_title: Shortest Path Pattern in Java – Complete Guide
+seo_title: Shortest Path Pattern in Java - Interview Preparation Guide
 seo_description: Master shortest path algorithms in Java including BFS for unweighted
   graphs and Dijkstra for weighted graphs.
 tags:
@@ -12,7 +12,7 @@ tags:
 - shortest-path
 - bfs
 - dijkstra
-title: Shortest Path Pattern in Java — A Detailed Guide
+title: Shortest Path Pattern in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-03-27-union-find-pattern.md
+++ b/_posts/2026-03-27-union-find-pattern.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-03-27
-seo_title: Union-Find (Disjoint Set) Pattern in Java – Complete Guide
+seo_title: Union-Find (Disjoint Set) Pattern in Java - Interview Preparation Guide
 seo_description: Learn Union-Find in Java with path compression and union by rank
   for connectivity and dynamic component problems.
 tags:
@@ -12,7 +12,7 @@ tags:
 - union-find
 - disjoint-set
 - graph
-title: Union-Find (Disjoint Set) Pattern in Java — A Detailed Guide
+title: Union-Find (Disjoint Set) Pattern in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-03-28-dynamic-programming-pattern.md
+++ b/_posts/2026-03-28-dynamic-programming-pattern.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-03-28
-seo_title: Dynamic Programming Pattern in Java – Complete Guide
+seo_title: Dynamic Programming Pattern in Java - Interview Preparation Guide
 seo_description: Master dynamic programming in Java with state definition, transitions,
   memoization, and tabulation patterns.
 tags:
@@ -12,7 +12,7 @@ tags:
 - dynamic-programming
 - dp
 - algorithms
-title: Dynamic Programming Pattern in Java — A Detailed Guide
+title: Dynamic Programming Pattern in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-03-29-trie-pattern.md
+++ b/_posts/2026-03-29-trie-pattern.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-03-29
-seo_title: Trie Pattern in Java – Complete Guide
+seo_title: Trie Pattern in Java - Interview Preparation Guide
 seo_description: Learn Trie in Java for prefix search, autocomplete, and dictionary-based
   backtracking problems.
 tags:
@@ -12,7 +12,7 @@ tags:
 - trie
 - prefix-tree
 - strings
-title: Trie Pattern in Java — A Detailed Guide
+title: Trie Pattern in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-04-01-bit-manipulation-pattern.md
+++ b/_posts/2026-04-01-bit-manipulation-pattern.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-04-01
-seo_title: Bit Manipulation Patterns in Java – Complete Guide
+seo_title: Bit Manipulation Patterns in Java - Interview Preparation Guide
 seo_description: Master bitwise operations in Java for masks, parity, subset states,
   and constant-memory optimizations.
 tags:
@@ -11,7 +11,7 @@ tags:
 - java
 - bit-manipulation
 - algorithms
-title: Bit Manipulation Patterns in Java — A Detailed Guide
+title: Bit Manipulation Patterns in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-04-02-greedy-algorithms-pattern.md
+++ b/_posts/2026-04-02-greedy-algorithms-pattern.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-04-02
-seo_title: Greedy Algorithms Pattern in Java – Complete Guide
+seo_title: Greedy Algorithms Pattern in Java - Interview Preparation Guide
 seo_description: Learn greedy strategy design in Java with proof mindset and classic
   scheduling/selection examples.
 tags:
@@ -11,7 +11,7 @@ tags:
 - java
 - greedy
 - algorithms
-title: Greedy Algorithms Pattern in Java — A Detailed Guide
+title: Greedy Algorithms Pattern in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-04-03-topological-sort-pattern.md
+++ b/_posts/2026-04-03-topological-sort-pattern.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-04-03
-seo_title: Topological Sort Pattern in Java – Complete Guide
+seo_title: Topological Sort Pattern in Java - Interview Preparation Guide
 seo_description: Solve dependency ordering problems in Java using Kahn BFS and DFS
   post-order methods.
 tags:
@@ -12,7 +12,7 @@ tags:
 - topological-sort
 - graph
 - algorithms
-title: Topological Sort Pattern in Java — A Detailed Guide
+title: Topological Sort Pattern in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-04-04-minimum-spanning-tree-pattern.md
+++ b/_posts/2026-04-04-minimum-spanning-tree-pattern.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-04-04
-seo_title: Minimum Spanning Tree Pattern in Java – Complete Guide
+seo_title: Minimum Spanning Tree Pattern in Java - Interview Preparation Guide
 seo_description: Build minimum-cost connected graphs in Java with Kruskal and Prim
   implementations.
 tags:
@@ -12,7 +12,7 @@ tags:
 - mst
 - graph
 - algorithms
-title: Minimum Spanning Tree Pattern in Java — A Detailed Guide
+title: Minimum Spanning Tree Pattern in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-04-05-strongly-connected-components-pattern.md
+++ b/_posts/2026-04-05-strongly-connected-components-pattern.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-04-05
-seo_title: SCC Pattern in Java – Complete Guide
+seo_title: SCC Pattern in Java - Interview Preparation Guide
 seo_description: Decompose directed graphs into SCCs in Java using Kosaraju and low-link
   concepts.
 tags:
@@ -12,7 +12,7 @@ tags:
 - scc
 - graph
 - algorithms
-title: Strongly Connected Components Pattern in Java — A Detailed Guide
+title: Strongly Connected Components Pattern in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-04-06-a-star-search-pattern.md
+++ b/_posts/2026-04-06-a-star-search-pattern.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-04-06
-seo_title: A* Search Pattern in Java – Complete Guide
+seo_title: A* Search Pattern in Java - Interview Preparation Guide
 seo_description: Use A* in Java for heuristic-guided shortest path search on grids
   and weighted maps.
 tags:
@@ -12,7 +12,7 @@ tags:
 - a-star
 - graph
 - pathfinding
-title: A* Search Pattern in Java — A Detailed Guide
+title: A* Search Pattern in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-04-07-floyd-warshall-algorithm.md
+++ b/_posts/2026-04-07-floyd-warshall-algorithm.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-04-07
-seo_title: Floyd-Warshall Algorithm in Java – Complete Guide
+seo_title: Floyd-Warshall Algorithm in Java - Interview Preparation Guide
 seo_description: Compute all-pairs shortest paths in Java with dynamic programming
   over intermediate nodes.
 tags:
@@ -12,7 +12,7 @@ tags:
 - floyd-warshall
 - graph
 - algorithms
-title: Floyd-Warshall Algorithm in Java — A Detailed Guide
+title: Floyd-Warshall Algorithm in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-04-08-bellman-ford-algorithm.md
+++ b/_posts/2026-04-08-bellman-ford-algorithm.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-04-08
-seo_title: Bellman-Ford Algorithm in Java – Complete Guide
+seo_title: Bellman-Ford Algorithm in Java - Interview Preparation Guide
 seo_description: Handle negative edge weights and detect negative cycles in Java using
   Bellman-Ford.
 tags:
@@ -12,7 +12,7 @@ tags:
 - bellman-ford
 - graph
 - algorithms
-title: Bellman-Ford Algorithm in Java — A Detailed Guide
+title: Bellman-Ford Algorithm in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-04-09-segment-tree-pattern.md
+++ b/_posts/2026-04-09-segment-tree-pattern.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-04-09
-seo_title: Segment Tree Pattern in Java – Complete Guide
+seo_title: Segment Tree Pattern in Java - Interview Preparation Guide
 seo_description: Answer mutable range queries in Java with segment tree templates
   and update/query patterns.
 tags:
@@ -12,7 +12,7 @@ tags:
 - segment-tree
 - range-query
 - algorithms
-title: Segment Tree Pattern in Java — A Detailed Guide
+title: Segment Tree Pattern in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-04-10-fenwick-tree-pattern.md
+++ b/_posts/2026-04-10-fenwick-tree-pattern.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-04-10
-seo_title: Fenwick Tree Pattern in Java – Complete Guide
+seo_title: Fenwick Tree Pattern in Java - Interview Preparation Guide
 seo_description: Use Binary Indexed Tree in Java for prefix sums and point updates
   in logarithmic time.
 tags:
@@ -12,7 +12,7 @@ tags:
 - fenwick-tree
 - bit
 - algorithms
-title: Fenwick Tree Pattern in Java — A Detailed Guide
+title: Fenwick Tree Pattern in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-04-11-sparse-table-range-query.md
+++ b/_posts/2026-04-11-sparse-table-range-query.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-04-11
-seo_title: Sparse Table Range Query Pattern in Java – Complete Guide
+seo_title: Sparse Table Range Query Pattern in Java - Interview Preparation Guide
 seo_description: Preprocess immutable arrays in Java for constant-time idempotent
   range queries.
 tags:
@@ -12,7 +12,7 @@ tags:
 - sparse-table
 - range-query
 - algorithms
-title: Sparse Table Range Query Pattern in Java — A Detailed Guide
+title: Sparse Table Range Query Pattern in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-04-12-suffix-array-lcp-basics.md
+++ b/_posts/2026-04-12-suffix-array-lcp-basics.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-04-12
-seo_title: Suffix Array and LCP Basics in Java – Complete Guide
+seo_title: Suffix Array and LCP Basics in Java - Interview Preparation Guide
 seo_description: Understand suffix array and LCP basics in Java for substring ranking
   and repetition analysis.
 tags:
@@ -12,7 +12,7 @@ tags:
 - suffix-array
 - lcp
 - strings
-title: Suffix Array and LCP Basics in Java — A Detailed Guide
+title: Suffix Array and LCP Basics in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-04-13-kmp-string-matching.md
+++ b/_posts/2026-04-13-kmp-string-matching.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-04-13
-seo_title: KMP String Matching in Java – Complete Guide
+seo_title: KMP String Matching in Java - Interview Preparation Guide
 seo_description: Implement linear-time substring search in Java using LPS prefix-function
   preprocessing.
 tags:
@@ -12,7 +12,7 @@ tags:
 - kmp
 - strings
 - algorithms
-title: KMP String Matching in Java — A Detailed Guide
+title: KMP String Matching in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-04-14-rabin-karp-string-matching.md
+++ b/_posts/2026-04-14-rabin-karp-string-matching.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-04-14
-seo_title: Rabin-Karp String Matching in Java – Complete Guide
+seo_title: Rabin-Karp String Matching in Java - Interview Preparation Guide
 seo_description: Use rolling hash in Java for efficient string matching and multi-pattern
   scanning.
 tags:
@@ -12,7 +12,7 @@ tags:
 - rabin-karp
 - rolling-hash
 - strings
-title: Rabin-Karp String Matching in Java — A Detailed Guide
+title: Rabin-Karp String Matching in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-04-15-z-algorithm-string-matching.md
+++ b/_posts/2026-04-15-z-algorithm-string-matching.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-04-15
-seo_title: Z-Algorithm String Matching in Java – Complete Guide
+seo_title: Z-Algorithm String Matching in Java - Interview Preparation Guide
 seo_description: Compute Z-array in Java for prefix-match based string search and
   border analysis.
 tags:
@@ -12,7 +12,7 @@ tags:
 - z-algorithm
 - strings
 - algorithms
-title: Z-Algorithm for String Matching in Java — A Detailed Guide
+title: Z-Algorithm for String Matching in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-04-16-manacher-algorithm-palindrome.md
+++ b/_posts/2026-04-16-manacher-algorithm-palindrome.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-04-16
-seo_title: Manacher Algorithm in Java – Complete Guide
+seo_title: Manacher Algorithm in Java - Interview Preparation Guide
 seo_description: Find longest palindromic substrings in linear time in Java with Manacher’s
   algorithm.
 tags:
@@ -12,7 +12,7 @@ tags:
 - manacher
 - palindrome
 - strings
-title: Manacher Algorithm for Palindromes in Java — A Detailed Guide
+title: Manacher Algorithm for Palindromes in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-04-17-rolling-hash-pattern.md
+++ b/_posts/2026-04-17-rolling-hash-pattern.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-04-17
-seo_title: Rolling Hash Pattern in Java – Complete Guide
+seo_title: Rolling Hash Pattern in Java - Interview Preparation Guide
 seo_description: Apply rolling hash in Java for substring comparison, duplicate detection,
   and string indexing.
 tags:
@@ -12,7 +12,7 @@ tags:
 - rolling-hash
 - strings
 - algorithms
-title: Rolling Hash Pattern in Java — A Detailed Guide
+title: Rolling Hash Pattern in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-04-18-meet-in-the-middle-pattern.md
+++ b/_posts/2026-04-18-meet-in-the-middle-pattern.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-04-18
-seo_title: Meet-in-the-Middle Pattern in Java – Complete Guide
+seo_title: Meet-in-the-Middle Pattern in Java - Interview Preparation Guide
 seo_description: Solve exponential subset problems faster in Java by splitting search
   space and merging results.
 tags:
@@ -11,7 +11,7 @@ tags:
 - java
 - meet-in-the-middle
 - algorithms
-title: Meet-in-the-Middle Pattern in Java — A Detailed Guide
+title: Meet-in-the-Middle Pattern in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-04-19-divide-and-conquer-pattern.md
+++ b/_posts/2026-04-19-divide-and-conquer-pattern.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-04-19
-seo_title: Divide and Conquer Pattern in Java – Complete Guide
+seo_title: Divide and Conquer Pattern in Java - Interview Preparation Guide
 seo_description: Structure recursive Java solutions with split-solve-merge for scalable
   problem decomposition.
 tags:
@@ -12,7 +12,7 @@ tags:
 - divide-and-conquer
 - recursion
 - algorithms
-title: Divide and Conquer Pattern in Java — A Detailed Guide
+title: Divide and Conquer Pattern in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-04-20-sweep-line-pattern.md
+++ b/_posts/2026-04-20-sweep-line-pattern.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-04-20
-seo_title: Sweep Line Pattern in Java – Complete Guide
+seo_title: Sweep Line Pattern in Java - Interview Preparation Guide
 seo_description: Process interval and geometry events in Java with sorted endpoints
   and active-state tracking.
 tags:
@@ -12,7 +12,7 @@ tags:
 - sweep-line
 - intervals
 - algorithms
-title: Sweep Line Pattern in Java — A Detailed Guide
+title: Sweep Line Pattern in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-04-21-coordinate-compression-pattern.md
+++ b/_posts/2026-04-21-coordinate-compression-pattern.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-04-21
-seo_title: Coordinate Compression Pattern in Java – Complete Guide
+seo_title: Coordinate Compression Pattern in Java - Interview Preparation Guide
 seo_description: Compress sparse numeric ranges in Java to dense indices for efficient
   array-based processing.
 tags:
@@ -11,7 +11,7 @@ tags:
 - java
 - coordinate-compression
 - algorithms
-title: Coordinate Compression Pattern in Java — A Detailed Guide
+title: Coordinate Compression Pattern in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-04-22-difference-array-range-update-pattern.md
+++ b/_posts/2026-04-22-difference-array-range-update-pattern.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-04-22
-seo_title: Difference Array Pattern in Java – Complete Guide
+seo_title: Difference Array Pattern in Java - Interview Preparation Guide
 seo_description: Apply multiple range updates efficiently in Java with difference
   arrays and prefix reconstruction.
 tags:
@@ -12,7 +12,7 @@ tags:
 - difference-array
 - prefix-sum
 - algorithms
-title: Difference Array Range Update Pattern in Java — A Detailed Guide
+title: Difference Array Range Update Pattern in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-04-23-binary-search-on-answer-advanced.md
+++ b/_posts/2026-04-23-binary-search-on-answer-advanced.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-04-23
-seo_title: Advanced Binary Search on Answer in Java – Complete Guide
+seo_title: Advanced Binary Search on Answer in Java - Interview Preparation Guide
 seo_description: Solve optimization constraints in Java by binary searching monotonic
   feasible answers.
 tags:
@@ -12,7 +12,7 @@ tags:
 - binary-search
 - optimization
 - algorithms
-title: Advanced Binary Search on Answer in Java — A Detailed Guide
+title: Advanced Binary Search on Answer in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-04-24-memoization-vs-tabulation-dp.md
+++ b/_posts/2026-04-24-memoization-vs-tabulation-dp.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-04-24
-seo_title: Memoization vs Tabulation in Java – Complete Guide
+seo_title: Memoization vs Tabulation in Java - Interview Preparation Guide
 seo_description: Choose the right DP execution model in Java with tradeoffs, templates,
   and performance implications.
 tags:
@@ -12,7 +12,7 @@ tags:
 - dp
 - memoization
 - tabulation
-title: Memoization vs Tabulation in Java DP — A Detailed Guide
+title: Memoization vs Tabulation in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-04-25-digit-dp-pattern.md
+++ b/_posts/2026-04-25-digit-dp-pattern.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-04-25
-seo_title: Digit DP Pattern in Java – Complete Guide
+seo_title: Digit DP Pattern in Java - Interview Preparation Guide
 seo_description: Count numbers under digit constraints in Java with tight-bound state
   transitions.
 tags:
@@ -12,7 +12,7 @@ tags:
 - digit-dp
 - dynamic-programming
 - algorithms
-title: Digit DP Pattern in Java — A Detailed Guide
+title: Digit DP Pattern in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-04-26-bitmask-dp-pattern.md
+++ b/_posts/2026-04-26-bitmask-dp-pattern.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-04-26
-seo_title: Bitmask DP Pattern in Java – Complete Guide
+seo_title: Bitmask DP Pattern in Java - Interview Preparation Guide
 seo_description: Model subset states in Java with bitmask DP for assignment, TSP-style,
   and covering problems.
 tags:
@@ -11,7 +11,7 @@ tags:
 - java
 - bitmask-dp
 - dynamic-programming
-title: Bitmask DP Pattern in Java — A Detailed Guide
+title: Bitmask DP Pattern in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-04-27-tree-dp-pattern.md
+++ b/_posts/2026-04-27-tree-dp-pattern.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-04-27
-seo_title: Tree DP Pattern in Java – Complete Guide
+seo_title: Tree DP Pattern in Java - Interview Preparation Guide
 seo_description: Compute optimal values on trees in Java by combining child DP states
   per node.
 tags:
@@ -11,7 +11,7 @@ tags:
 - java
 - tree-dp
 - dynamic-programming
-title: Tree DP Pattern in Java — A Detailed Guide
+title: Tree DP Pattern in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-04-28-game-theory-dp-minimax.md
+++ b/_posts/2026-04-28-game-theory-dp-minimax.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-04-28
-seo_title: Game Theory DP Minimax in Java – Complete Guide
+seo_title: Game Theory DP Minimax in Java - Interview Preparation Guide
 seo_description: Model two-player optimal play in Java with minimax recurrence and
   memoization.
 tags:
@@ -12,7 +12,7 @@ tags:
 - game-theory
 - minimax
 - dp
-title: Game Theory DP (Minimax) in Java — A Detailed Guide
+title: Game Theory DP (Minimax) in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-04-29-lru-lfu-cache-design.md
+++ b/_posts/2026-04-29-lru-lfu-cache-design.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-04-29
-seo_title: LRU LFU Cache Design in Java – Complete Guide
+seo_title: LRU LFU Cache Design in Java - Interview Preparation Guide
 seo_description: Design O(1) LRU/LFU caches in Java using hash maps and linked/bucket
   structures.
 tags:
@@ -12,7 +12,7 @@ tags:
 - cache-design
 - lru
 - lfu
-title: LRU and LFU Cache Design in Java — A Detailed Guide
+title: LRU and LFU Cache Design in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article

--- a/_posts/2026-04-30-discrete-event-simulation-pattern.md
+++ b/_posts/2026-04-30-discrete-event-simulation-pattern.md
@@ -3,7 +3,7 @@ categories:
 - DSA
 - Java
 date: 2026-04-30
-seo_title: Discrete Event Simulation Pattern in Java – Complete Guide
+seo_title: Discrete Event Simulation Pattern in Java - Interview Preparation Guide
 seo_description: Simulate asynchronous systems in Java using time-ordered event queues
   and state transitions.
 tags:
@@ -12,7 +12,7 @@ tags:
 - simulation
 - priority-queue
 - algorithms
-title: Discrete Event Simulation Pattern in Java — A Detailed Guide
+title: Discrete Event Simulation Pattern in Java - Interview Preparation Guide
 toc: true
 toc_icon: cog
 toc_label: In This Article


### PR DESCRIPTION
- rename DSA pattern and technique posts to use the Interview Preparation Guide format
- align title and seo_title across two-pointers, sliding-window, and related Java DSA guides
- improve naming consistency across the March-April 2026 interview-prep series